### PR TITLE
Check for NAs before trying to rearrange or identify stages

### DIFF
--- a/Mage/R/rearrangeMatrix.R
+++ b/Mage/R/rearrangeMatrix.R
@@ -25,10 +25,19 @@ rearrangeMatrix <- function(matU, matF, matFmu) {
   if (!(identical(dim(matU), dim(matF)) && identical(dim(matF), dim(matFmu)))) {
     stop("Expecting matrices with equal dimensions", call. = FALSE)
   }
+  if (any(is.na(matFmu))) {
+    ## Assume that NAs correspond to unknown fecundities; replace with Inf so
+    ## that reproductive stages are correctly identified.
+    matFmu[which(is.na(matFmu))] <- Inf
+  }
   reArrange <- NULL
   matDim <- dim(matF)[1]
   Rep <- which(colSums(matFmu) > 0)
-  allRep <- Rep[1]:Rep[length(Rep)]
+  if (length(Rep) > 0) {
+    allRep <- Rep[1]:Rep[length(Rep)]
+  } else {
+    allRep <- integer(0)
+  }
   ## These are stages that are inter-reproductive but are truly non-reproductive:
   nonRepInterRep <- allRep[which(!allRep %in% Rep)]
   if (length(nonRepInterRep) > 0) {
@@ -46,7 +55,7 @@ rearrangeMatrix <- function(matU, matF, matFmu) {
   ## Stages that were moved to the end
   reArrange$nonRepInterRep <- nonRepInterRep
   ## Max reproductive stage after rearrangement
-  reArrange$maxRep <- max(which(colSums(reArrange$matFmu) > 0))
-
+  rearrRep <- which(colSums(reArrange$matFmu) > 0)
+  reArrange$maxRep <- ifelse(length(rearrRep) > 0, max(rearrRep), 0)
   return(reArrange)
 }

--- a/Mage/R/reprodStages.R
+++ b/Mage/R/reprodStages.R
@@ -75,15 +75,25 @@ reprodStages <- function(matF, matFmu, post, maxRep, matrixStages,
     propStage <- NA
   }
 
+  if (any(is.na(matFmu))) {
+    ## Assume that NAs correspond to unknown fecundities; replace with Inf so
+    ## that reproductive stages are correctly identified.
+    matFmu[which(is.na(matFmu))] <- Inf
+  }
+
   # prerep
   matDim <- dim(matF)[1]
   Rep <- which(colSums(matFmu) > 0)
-  if (min(Rep) == 1) {
-    preRep <- NA
-  } else if (!is.na(propStage[1]) && (min(Rep) - max(propStage) == 1)) {
-    preRep <- NA
+  if (length(Rep) > 0) {
+    if (min(Rep) == 1) {
+      preRep <- NA
+    } else if (!is.na(propStage[1]) && (min(Rep) - max(propStage) == 1)) {
+      preRep <- NA
+    } else {
+      preRep <- min(which(matrixStages == "active")):(min(Rep) - 1)
+    }
   } else {
-    preRep <- min(which(matrixStages == "active")):(min(Rep) - 1)
+    preRep <- NA
   }
 
   # postrep


### PR DESCRIPTION
Check for NAs in mean fecundity matrix before trying to rearrange or
identify stages. If found, replace with Inf to allow identification
of reproductive stages (assuming that NAs represent an unknown
fecundity rate in the matrix model).

Also, adjust code to check that one or more reproductive stages have
been found before trying to get length/min/max of the list of stages.

Fixes jonesor/compadreDB/issues/15.